### PR TITLE
msm8960-common: remove languages-full.mk

### DIFF
--- a/msm8960.mk
+++ b/msm8960.mk
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-$(call inherit-product, $(SRC_TARGET_DIR)/product/languages_full.mk)
-
 # Permissions
 PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.camera.flash-autofocus.xml:system/etc/permissions/android.hardware.camera.flash-autofocus.xml \


### PR DESCRIPTION
*  languages_full.mk is inherited by locales_full.mk which is inherited by full_base.mk

Change-Id: I641f6215a3301c806535776aeff7661669758679